### PR TITLE
Clone submodules using HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "etcd-browser"]
 	path = etcd-browser
-	url = git@github.com:henszey/etcd-browser.git
+	url = https://github.com/henszey/etcd-browser.git

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation of Cloudiator using Docker (docker-compose).
 * install Docker: https://docs.docker.com/install/
 * install docker-compose: https://docs.docker.com/compose/install/
 * install git
-* git clone the repository: git clone https://github.com/cloudiator/docker.git
+* git clone the repository: git clone --recurse-submodules https://github.com/cloudiator/docker.git
 * edit the env-template to e.g. to use own API-Key-Token
 * cp the env-template to .env: cp env-template .env
 * run docker-compose up


### PR DESCRIPTION
`git clone` via ssh requires key added to GitHub account, so I suggest changing submodule url to https, which doesn't need additional setup.